### PR TITLE
Rename and make modules public

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::num::ParseIntError;
 
 #[derive(Debug)]
-pub enum SdpParserResult {
+pub enum SdpParserError {
     ParserLineError { message: String, line: String },
     ParserUnsupported { message: String, line: String },
     ParserSequence {
@@ -10,10 +10,10 @@ pub enum SdpParserResult {
     },
 }
 
-impl From<ParseIntError> for SdpParserResult {
-    fn from(_: ParseIntError) -> SdpParserResult {
+impl From<ParseIntError> for SdpParserError {
+    fn from(_: ParseIntError) -> Self {
         // TODO empty line error here makes no sense
-        SdpParserResult::ParserLineError {
+        SdpParserError::ParserLineError {
             message: "failed to parse integer".to_string(),
             line: "".to_string(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 
 use std::net::IpAddr;
 
-mod attribute_type;
-mod error;
-mod media_type;
-mod network;
-mod unsupported_types;
+pub mod attribute_type;
+pub mod error;
+pub mod media_type;
+pub mod network;
+pub mod unsupported_types;
 
 use attribute_type::{SdpAttribute, parse_attribute};
 use error::SdpParserResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod network;
 pub mod unsupported_types;
 
 use attribute_type::{SdpAttribute, parse_attribute};
-use error::SdpParserResult;
+use error::SdpParserError;
 use media_type::{SdpMedia, SdpMediaLine, parse_media, parse_media_vector};
 use network::{SdpNetType, SdpAddrType, parse_addrtype, parse_nettype, parse_unicast_addr};
 use unsupported_types::{parse_email, parse_information, parse_key, parse_phone, parse_repeat, parse_uri, parse_zone};
@@ -187,7 +187,7 @@ impl SdpSession {
     }
 }
 
-fn parse_session(value: &str) -> Result<SdpLine, SdpParserResult> {
+fn parse_session(value: &str) -> Result<SdpLine, SdpParserError> {
     println!("session: {}", value);
     Ok(SdpLine::Session {value: String::from(value)})
 }
@@ -198,10 +198,10 @@ fn test_session_works() {
 }
 
 
-fn parse_version(value: &str) -> Result<SdpLine, SdpParserResult> {
+fn parse_version(value: &str) -> Result<SdpLine, SdpParserError> {
     let ver = try!(value.parse::<u64>());
     if ver != 0 {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "unsupported version in v field".to_string(),
             line: value.to_string() });
     };
@@ -221,10 +221,10 @@ fn test_version_unsupported_input() {
     assert!(parse_version("a").is_err());
 }
 
-fn parse_origin(value: &str) -> Result<SdpLine, SdpParserResult> {
+fn parse_origin(value: &str) -> Result<SdpLine, SdpParserError> {
     let ot: Vec<&str> = value.split_whitespace().collect();
     if ot.len() != 6 {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "origin field must have six tokens".to_string(),
             line: value.to_string() });
     }
@@ -279,10 +279,10 @@ fn test_origin_addr_type_mismatch() {
     assert!(parse_origin("mozilla 506705521068071134 0 IN IP4 ::1").is_err());
 }
 
-fn parse_connection(value: &str) -> Result<SdpLine, SdpParserResult> {
+fn parse_connection(value: &str) -> Result<SdpLine, SdpParserError> {
     let cv: Vec<&str> = value.split_whitespace().collect();
     if cv.len() != 3 {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "connection attribute must have three tokens".to_string(),
             line: value.to_string() });
     }
@@ -348,10 +348,10 @@ fn connection_addr_type_mismatch() {
     assert!(parse_connection("IN IP4 ::1").is_err());
 }
 
-fn parse_bandwidth(value: &str) -> Result<SdpLine, SdpParserResult> {
+fn parse_bandwidth(value: &str) -> Result<SdpLine, SdpParserError> {
     let bv: Vec<&str> = value.split(':').collect();
     if bv.len() != 2 {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "bandwidth attribute must have two tokens".to_string(),
             line: value.to_string() });
     }
@@ -392,10 +392,10 @@ fn bandwidth_unsupported_type() {
     assert!(parse_bandwidth("UNSUPPORTED:12345").is_ok());
 }
 
-fn parse_timing(value: &str) -> Result<SdpLine, SdpParserResult> {
+fn parse_timing(value: &str) -> Result<SdpLine, SdpParserError> {
     let tv: Vec<&str> = value.split_whitespace().collect();
     if tv.len() != 2 {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "timing attribute must have two tokens".to_string(),
             line: value.to_string() });
     }
@@ -424,27 +424,27 @@ fn test_timing_wrong_amount_of_tokens() {
     assert!(parse_timing("0 0 0").is_err());
 }
 
-fn parse_sdp_line(line: &str) -> Result<SdpLine, SdpParserResult> {
+fn parse_sdp_line(line: &str) -> Result<SdpLine, SdpParserError> {
     if line.find('=') == None {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "missing = character in line".to_string(),
             line: line.to_string() });
     }
     let v: Vec<&str> = line.splitn(2, '=').collect();
     if v.len() < 2 {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "failed to split field and attribute".to_string(),
             line: line.to_string() });
     };
     let name = v[0].trim();
     if name.is_empty() || name.len() > 1 {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "field name empty or too long".to_string(),
             line: line.to_string() });
     };
     let value = v[1].trim();
     if value.is_empty() {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "attribute value has zero length".to_string(),
             line: line.to_string() });
     }
@@ -464,7 +464,7 @@ fn parse_sdp_line(line: &str) -> Result<SdpLine, SdpParserResult> {
         "u" => { parse_uri(value) },
         "v" => { parse_version(value) },
         "z" => { parse_zone(value) },
-        _   => { Err(SdpParserResult::ParserLineError {
+        _   => { Err(SdpParserError::ParserLineError {
                     message: "unsupported sdp field".to_string(),
                     line: line.to_string() }) }
     }
@@ -509,9 +509,9 @@ fn test_parse_sdp_line_invalid_a_line() {
 }
 
 // TODO add unit tests
-fn parse_sdp_vector(lines: &[SdpLine]) -> Result<SdpSession, SdpParserResult> {
+fn parse_sdp_vector(lines: &[SdpLine]) -> Result<SdpSession, SdpParserError> {
     if lines.len() < 5 {
-        return Err(SdpParserResult::ParserSequence {
+        return Err(SdpParserError::ParserSequence {
             message: "SDP neeeds at least 5 lines".to_string(),
             line: None })
     }
@@ -519,19 +519,19 @@ fn parse_sdp_vector(lines: &[SdpLine]) -> Result<SdpSession, SdpParserResult> {
     // TODO are these mataches really the only way to verify the types?
     let version: u64 = match lines[0] {
         SdpLine::Version{value: v} => v,
-        _ => return Err(SdpParserResult::ParserSequence {
+        _ => return Err(SdpParserError::ParserSequence {
             message: "first line needs to be version number".to_string(),
             line: None })
     };
     let origin: SdpOrigin = match lines[1] {
         SdpLine::Origin{value: ref v} => v.clone(),
-        _ => return Err(SdpParserResult::ParserSequence {
+        _ => return Err(SdpParserError::ParserSequence {
             message: "second line needs to be origin".to_string(),
             line: None })
     };
     let session: String = match lines[2] {
         SdpLine::Session{value: ref v} => v.clone(),
-        _ => return Err(SdpParserResult::ParserSequence {
+        _ => return Err(SdpParserError::ParserSequence {
             message: "third line needs to be session".to_string(),
             line: None })
     };
@@ -548,7 +548,7 @@ fn parse_sdp_vector(lines: &[SdpLine]) -> Result<SdpSession, SdpParserResult> {
                                   },
             SdpLine::Origin{..} |
             SdpLine::Session{..} |
-            SdpLine::Version{..} => return Err(SdpParserResult::ParserSequence {
+            SdpLine::Version{..} => return Err(SdpParserError::ParserSequence {
                                                         message: "internal parser error".to_string(),
                                                         line: Some(i)}),
             // TODO does anyone really ever need these?
@@ -562,30 +562,30 @@ fn parse_sdp_vector(lines: &[SdpLine]) -> Result<SdpSession, SdpParserResult> {
         };
     }
     if !sdp_session.has_timing() {
-        return Err(SdpParserResult::ParserSequence {
+        return Err(SdpParserError::ParserSequence {
             message: "Missing timing".to_string(),
             line: None},);
     }
     if !sdp_session.has_media() {
-        return Err(SdpParserResult::ParserSequence {
+        return Err(SdpParserError::ParserSequence {
             message: "Missing media".to_string(),
             line: None},);
     }
     Ok(sdp_session)
 }
 
-pub fn parse_sdp(sdp: &str, fail_on_warning: bool) -> Result<SdpSession, SdpParserResult> {
+pub fn parse_sdp(sdp: &str, fail_on_warning: bool) -> Result<SdpSession, SdpParserError> {
     if sdp.is_empty() {
-        return Err(SdpParserResult::ParserLineError{message: "empty SDP".to_string(),
+        return Err(SdpParserError::ParserLineError{message: "empty SDP".to_string(),
                                                             line: "".to_string()});
     }
     if sdp.len() < 62 {
-        return Err(SdpParserResult::ParserLineError{message: "string to short to be valid SDP".to_string(),
+        return Err(SdpParserError::ParserLineError{message: "string to short to be valid SDP".to_string(),
                                                             line: sdp.to_string()});
     }
     let lines = sdp.lines();
-    let mut errors: Vec<SdpParserResult> = Vec::new();
-    let mut warnings: Vec<SdpParserResult> = Vec::new();
+    let mut errors: Vec<SdpParserError> = Vec::new();
+    let mut warnings: Vec<SdpParserError> = Vec::new();
     let mut sdp_lines: Vec<SdpLine> = Vec::new();
     for line in lines {
         let stripped_line = line.trim();
@@ -597,15 +597,15 @@ pub fn parse_sdp(sdp: &str, fail_on_warning: bool) -> Result<SdpSession, SdpPars
             Err(e) => {
                 match e {
                     // FIXME is this really a good way to accomplish this?
-                    SdpParserResult::ParserLineError { message: x, line: y } =>
-                        { errors.push(SdpParserResult::ParserLineError { message: x, line: y}) },
-                    SdpParserResult::ParserUnsupported { message: x, line: y } =>
+                    SdpParserError::ParserLineError { message: x, line: y } =>
+                        { errors.push(SdpParserError::ParserLineError { message: x, line: y}) },
+                    SdpParserError::ParserUnsupported { message: x, line: y } =>
                         {
                             println!("Warning unsupported value encountered: {}\n in line {}", x, y);
-                            warnings.push(SdpParserResult::ParserUnsupported { message: x, line: y});
+                            warnings.push(SdpParserError::ParserUnsupported { message: x, line: y});
                         },
-                    SdpParserResult::ParserSequence {message: x, line: y} =>
-                        { errors.push(SdpParserResult::ParserSequence { message: x, line: y})}
+                    SdpParserError::ParserSequence {message: x, line: y} =>
+                        { errors.push(SdpParserError::ParserSequence { message: x, line: y})}
                 }
             }
         };
@@ -615,7 +615,7 @@ pub fn parse_sdp(sdp: &str, fail_on_warning: bool) -> Result<SdpSession, SdpPars
             return Err(warning);
         } else {
             match warning {
-                SdpParserResult::ParserUnsupported { message: msg, line: l} =>
+                SdpParserError::ParserUnsupported { message: msg, line: l} =>
                     { println!("Parser unknown: {}\n  in line: {}", msg, l) },
                 _ => panic!(),
             };
@@ -624,9 +624,9 @@ pub fn parse_sdp(sdp: &str, fail_on_warning: bool) -> Result<SdpSession, SdpPars
     for error in errors {
         /*
         match error {
-            SdpParserResult::ParserLineError { message: msg, line: l} =>
+            SdpParserError::ParserLineError { message: msg, line: l} =>
                 { println!("Parser error: {}\n  in line: {}", msg, l) },
-            SdpParserResult::ParserSequence { message: msg, ..} =>
+            SdpParserError::ParserSequence { message: msg, ..} =>
                 { println!("Parser sequence: {}", msg)}
             _ => panic!(),
         };

--- a/src/network.rs
+++ b/src/network.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use error::SdpParserResult;
+use error::SdpParserError;
 
 #[derive(Clone,Debug,PartialEq)]
 pub enum SdpNetType {
@@ -31,9 +31,9 @@ impl fmt::Display for SdpAddrType {
     }
 }
 
-pub fn parse_nettype(value: &str) -> Result<SdpNetType, SdpParserResult> {
+pub fn parse_nettype(value: &str) -> Result<SdpNetType, SdpParserError> {
     if value.to_uppercase() != "IN" {
-        return Err(SdpParserResult::ParserLineError {
+        return Err(SdpParserError::ParserLineError {
             message: "nettype needs to be IN".to_string(),
             line: value.to_string() });
     };
@@ -50,11 +50,11 @@ fn test_parse_nettype() {
     assert!(parse_nettype("FOO").is_err());
 }
 
-pub fn parse_addrtype(value: &str) -> Result<SdpAddrType, SdpParserResult> {
+pub fn parse_addrtype(value: &str) -> Result<SdpAddrType, SdpParserError> {
     Ok(match value.to_uppercase().as_ref() {
         "IP4" => SdpAddrType::IP4,
         "IP6" => SdpAddrType::IP6,
-        _ => return Err(SdpParserResult::ParserLineError {
+        _ => return Err(SdpParserError::ParserLineError {
             message: "address type needs to be IP4 or IP6".to_string(),
             line: value.to_string() })
     })
@@ -73,12 +73,12 @@ fn test_parse_addrtype() {
     assert!(parse_addrtype("IP5").is_err());
 }
 
-pub fn parse_unicast_addr(addrtype: &SdpAddrType, value: &str) -> Result<IpAddr, SdpParserResult> {
+pub fn parse_unicast_addr(addrtype: &SdpAddrType, value: &str) -> Result<IpAddr, SdpParserError> {
     Ok(match *addrtype {
         SdpAddrType::IP4 => {
             IpAddr::V4(match Ipv4Addr::from_str(value) {
                 Ok(n) => n,
-                Err(_) => return Err(SdpParserResult::ParserLineError {
+                Err(_) => return Err(SdpParserError::ParserLineError {
                     message: "failed to parse unicast IP4 address attribute".to_string(),
                     line: value.to_string() })
             })
@@ -86,7 +86,7 @@ pub fn parse_unicast_addr(addrtype: &SdpAddrType, value: &str) -> Result<IpAddr,
         SdpAddrType::IP6 => {
             IpAddr::V6(match Ipv6Addr::from_str(value) {
                 Ok(n) => n,
-                Err(_) => return Err(SdpParserResult::ParserLineError {
+                Err(_) => return Err(SdpParserError::ParserLineError {
                     message: "failed to parse unicast IP6 address attribute".to_string(),
                     line: value.to_string() })
             })
@@ -94,7 +94,7 @@ pub fn parse_unicast_addr(addrtype: &SdpAddrType, value: &str) -> Result<IpAddr,
     })
 }
 
-pub fn parse_unicast_addr_unknown_type(value: &str) -> Result<IpAddr, SdpParserResult> {
+pub fn parse_unicast_addr_unknown_type(value: &str) -> Result<IpAddr, SdpParserError> {
     if value.find('.') == None {
         parse_unicast_addr(&SdpAddrType::IP6, value)
     } else {

--- a/src/unsupported_types.rs
+++ b/src/unsupported_types.rs
@@ -1,7 +1,7 @@
-use error::SdpParserResult;
+use error::SdpParserError;
 use SdpLine;
 
-pub fn parse_repeat(value: &str) -> Result<SdpLine, SdpParserResult> {
+pub fn parse_repeat(value: &str) -> Result<SdpLine, SdpParserError> {
     // TODO implement this if it's ever needed
     println!("repeat: {}", value);
     Ok(SdpLine::Repeat { value: String::from(value) })
@@ -13,7 +13,7 @@ fn test_repeat_works() {
     assert!(parse_repeat("0 0").is_ok());
 }
 
-pub fn parse_zone(value: &str) -> Result<SdpLine, SdpParserResult> {
+pub fn parse_zone(value: &str) -> Result<SdpLine, SdpParserError> {
     // TODO implement this if it's ever needed
     println!("zone: {}", value);
     Ok(SdpLine::Zone { value: String::from(value) })
@@ -25,7 +25,7 @@ fn test_zone_works() {
     assert!(parse_zone("0 0").is_ok());
 }
 
-pub fn parse_key(value: &str) -> Result<SdpLine, SdpParserResult> {
+pub fn parse_key(value: &str) -> Result<SdpLine, SdpParserError> {
     // TODO implement this if it's ever needed
     println!("key: {}", value);
     Ok(SdpLine::Key { value: String::from(value) })
@@ -37,7 +37,7 @@ fn test_keys_works() {
     assert!(parse_key("12345").is_ok());
 }
 
-pub fn parse_information(value: &str) -> Result<SdpLine, SdpParserResult> {
+pub fn parse_information(value: &str) -> Result<SdpLine, SdpParserError> {
     println!("information: {}", value);
     Ok(SdpLine::Information { value: String::from(value) })
 }
@@ -47,7 +47,7 @@ fn test_information_works() {
     assert!(parse_information("foobar").is_ok());
 }
 
-pub fn parse_uri(value: &str) -> Result<SdpLine, SdpParserResult> {
+pub fn parse_uri(value: &str) -> Result<SdpLine, SdpParserError> {
     // TODO check if this is really a URI
     println!("uri: {}", value);
     Ok(SdpLine::Uri { value: String::from(value) })
@@ -58,7 +58,7 @@ fn test_uri_works() {
     assert!(parse_uri("http://www.mozilla.org").is_ok());
 }
 
-pub fn parse_email(value: &str) -> Result<SdpLine, SdpParserResult> {
+pub fn parse_email(value: &str) -> Result<SdpLine, SdpParserError> {
     // TODO check if this is really an email address
     println!("email: {}", value);
     Ok(SdpLine::Email { value: String::from(value) })
@@ -69,7 +69,7 @@ fn test_email_works() {
     assert!(parse_email("nils@mozilla.com").is_ok());
 }
 
-pub fn parse_phone(value: &str) -> Result<SdpLine, SdpParserResult> {
+pub fn parse_phone(value: &str) -> Result<SdpLine, SdpParserError> {
     // TODO check if this is really a phone number
     println!("phone: {}", value);
     Ok(SdpLine::Phone { value: String::from(value) })


### PR DESCRIPTION
This pull request does two things. First, it makes the modules public so other code can use what is in them. Second, it renames SdpParserResult to SdpParserError.