### PR TITLE
Add optional support for serde serialization of parse results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,25 @@ os:
 # Taken out temporarily because it's to slow
 #  - osx
 
-rust:
-  - nightly
-  - beta
-  - stable
-  # mimimum stable version because we use init shorthand
-  - 1.17.0
+matrix:
+  include:
+    - rust: nightly
+    - rust: nightly
+      env:
+      - FEATURES="serialize"
+    - rust: beta
+    - rust: beta
+      env:
+      - FEATURES="serialize"
+    - rust: stable
+    - rust: stable
+      env:
+      - FEATURES="serialize"
+    # mimimum stable version because we use init shorthand
+    - rust: 1.17.0
+    - rust: 1.17.0
+      env:
+      - FEATURES="serialize"
 
 matrix:
   allow_failures:
@@ -48,7 +61,7 @@ script:
 
 after_success:
   - |
-      if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+      if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" && "$FEATURES" == "serialize" ]]; then
         wget https://github.com/SimonKagstrom/kcov/archive/v34.tar.gz &&
         tar xzf v34.tar.gz &&
         cd kcov-34 &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ after_success:
         rm -rf kcov-34 &&
         kcov --version &&
         (cd target/debug/ && ls -al) &&
-        for file in target/debug/rsdparsa-*.d; do file=${file::-2}; echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
-        for file in target/debug/unit_tests-*.d; do file=${file::-2}; echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
+        for file in target/debug/rsdparsa-*[^\.d]; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
+        for file in target/debug/unit_tests-*[^\.d]; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
         bash <(curl -s https://codecov.io/bash) &&
         echo "Uploaded code coverage"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ after_success:
         cd ../.. &&
         rm -rf kcov-34 &&
         kcov --version &&
+        (cd target/debug/ && ls -al) &&
         for file in target/debug/rsdparsa-*[^\.d]; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
         for file in target/debug/unit_tests-*[^\.d]; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
         bash <(curl -s https://codecov.io/bash) &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,15 @@ os:
 # Taken out temporarily because it's to slow
 #  - osx
 
-matrix:
-  include:
-    - rust: nightly
-    - rust: nightly
-      env:
-      - FEATURES="serialize"
-    - rust: beta
-    - rust: beta
-      env:
-      - FEATURES="serialize"
-    - rust: stable
-    - rust: stable
-      env:
-      - FEATURES="serialize"
-    # mimimum stable version because we use init shorthand
-    - rust: 1.17.0
-    - rust: 1.17.0
-      env:
-      - FEATURES="serialize"
+env:
+  - FEATURES=""
+  - FEATURES="serialize"
+rust:
+  - nightly
+  - beta
+  - stable
+  # mimimum stable version because we use init shorthand
+  - 1.17.0
 
 matrix:
   allow_failures:
@@ -51,7 +41,8 @@ before_script:
     fi
 
 script:
-  - cargo build --verbose --all
+  - echo FEATURES="$FEATURES"
+  - cargo build --verbose --all --features="$FEATURES"
   - |
     if [[ "$TRAVIS_RUST_VERSION" == "nightly" &&
       -f ~/.cargo/bin/cargo-clippy ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ after_success:
         rm -rf kcov-34 &&
         kcov --version &&
         (cd target/debug/ && ls -al) &&
-        for file in target/debug/rsdparsa-*.d; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
-        for file in target/debug/unit_tests-*.d; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
+        for file in target/debug/rsdparsa-*.d; do file=${file::-2}; echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
+        for file in target/debug/unit_tests-*.d; do file=${file::-2}; echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
         bash <(curl -s https://codecov.io/bash) &&
         echo "Uploaded code coverage"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ after_success:
         rm -rf kcov-34 &&
         kcov --version &&
         (cd target/debug/ && ls -al) &&
-        for file in target/debug/rsdparsa-*[^\.d]; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
-        for file in target/debug/unit_tests-*[^\.d]; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
+        for file in target/debug/rsdparsa-*.d; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
+        for file in target/debug/unit_tests-*.d; do echo "$file"; mkdir -p "target/cov/$(basename $file)"; kcov --verify --exclude-pattern=/.cargo,/usr/lib "target/cov/$(basename $file)" "$file"; done &&
         bash <(curl -s https://codecov.io/bash) &&
         echo "Uploaded code coverage"
       fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ serialize = ["serde", "serde_derive"]
 
 [dependencies]
 clippy = {version = "*", optional = true}
-serde = {version = "1.0.27" , optional = true}
-serde_derive = {version = "1.0.27" , optional = true}
+serde = {version = "1.0" , optional = true}
+serde_derive = {version = "1.0" , optional = true}
+
+[dev-dependencies]
+serde_json = {version = "1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,12 @@ name = "rsdparsa"
 version = "0.1.0"
 authors = ["Nils Ohlmeier <github@ohlmeier.org>"]
 
-[dependencies]
-clippy = {version = "*", optional = true}
-
 [features]
 default = []
+# json
+serialize = ["serde", "serde_derive"]
+
+[dependencies]
+clippy = {version = "*", optional = true}
+serde = {version = "1.0.27" , optional = true}
+serde_derive = {version = "1.0.27" , optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Nils Ohlmeier <github@ohlmeier.org>"]
 
 [features]
 default = []
-# json
+# serializability
 serialize = ["serde", "serde_derive"]
 
 [dependencies]

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -7,14 +7,14 @@ use error::SdpParserInternalError;
 use network::{parse_nettype, parse_addrtype, parse_unicast_addr};
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpAttributeCandidateTransport {
     Udp,
     Tcp,
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpAttributeCandidateType {
     Host,
     Srflx,
@@ -23,7 +23,7 @@ pub enum SdpAttributeCandidateType {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpAttributeCandidateTcpType {
     Active,
     Passive,
@@ -31,7 +31,7 @@ pub enum SdpAttributeCandidateTcpType {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeCandidate {
     pub foundation: String,
     pub component: u32,
@@ -100,7 +100,7 @@ impl SdpAttributeCandidate {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeRemoteCandidate {
     pub component: u32,
     pub address: IpAddr,
@@ -108,7 +108,7 @@ pub struct SdpAttributeRemoteCandidate {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeSimulcastId {
     pub id: String,
     pub paused: bool,
@@ -131,7 +131,7 @@ impl SdpAttributeSimulcastId {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeSimulcastAlternatives {
     pub ids: Vec<SdpAttributeSimulcastId>,
 }
@@ -149,7 +149,7 @@ impl SdpAttributeSimulcastAlternatives {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeSimulcast {
     pub send: Vec<SdpAttributeSimulcastAlternatives>,
     pub receive: Vec<SdpAttributeSimulcastAlternatives>,
@@ -172,7 +172,7 @@ impl SdpAttributeSimulcast {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeRtcp {
     pub port: u16,
     pub unicast_addr: Option<IpAddr>,
@@ -192,7 +192,7 @@ impl SdpAttributeRtcp {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeRtcpFb {
     pub payload_type: u32,
     // TODO parse this and use an enum instead?
@@ -200,7 +200,7 @@ pub struct SdpAttributeRtcpFb {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpAttributeDirection {
     Recvonly,
     Sendonly,
@@ -208,7 +208,7 @@ pub enum SdpAttributeDirection {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeExtmap {
     pub id: u16,
     pub direction: Option<SdpAttributeDirection>,
@@ -217,14 +217,14 @@ pub struct SdpAttributeExtmap {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeFmtp {
     pub payload_type: u8,
     pub tokens: Vec<String>,
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeFingerprint {
     // TODO turn the supported hash algorithms into an enum?
     pub hash_algorithm: String,
@@ -232,14 +232,14 @@ pub struct SdpAttributeFingerprint {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeSctpmap {
     pub port: u16,
     pub channels: u32,
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpAttributeGroupSemantic {
     LipSynchronization,
     FlowIdentification,
@@ -251,28 +251,28 @@ pub enum SdpAttributeGroupSemantic {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeGroup {
     pub semantics: SdpAttributeGroupSemantic,
     pub tags: Vec<String>,
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeMsid {
     pub id: String,
     pub appdata: Option<String>,
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeMsidSemantic {
     pub semantic: String,
     pub msids: Vec<String>,
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeRtpmap {
     pub payload_type: u8,
     pub codec_name: String,
@@ -296,7 +296,7 @@ impl SdpAttributeRtpmap {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpAttributeSetup {
     Active,
     Actpass,
@@ -305,7 +305,7 @@ pub enum SdpAttributeSetup {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpAttributeSsrc {
     pub id: u32,
     pub attribute: Option<String>,
@@ -333,7 +333,7 @@ impl SdpAttributeSsrc {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpAttribute {
     BundleOnly,
     Candidate(SdpAttributeCandidate),

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -7,12 +7,14 @@ use error::SdpParserInternalError;
 use network::{parse_nettype, parse_addrtype, parse_unicast_addr};
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpAttributeCandidateTransport {
     Udp,
     Tcp,
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpAttributeCandidateType {
     Host,
     Srflx,
@@ -21,6 +23,7 @@ pub enum SdpAttributeCandidateType {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpAttributeCandidateTcpType {
     Active,
     Passive,
@@ -28,6 +31,7 @@ pub enum SdpAttributeCandidateTcpType {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeCandidate {
     pub foundation: String,
     pub component: u32,
@@ -96,6 +100,7 @@ impl SdpAttributeCandidate {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeRemoteCandidate {
     pub component: u32,
     pub address: IpAddr,
@@ -103,6 +108,7 @@ pub struct SdpAttributeRemoteCandidate {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeSimulcastId {
     pub id: String,
     pub paused: bool,
@@ -125,6 +131,7 @@ impl SdpAttributeSimulcastId {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeSimulcastAlternatives {
     pub ids: Vec<SdpAttributeSimulcastId>,
 }
@@ -142,6 +149,7 @@ impl SdpAttributeSimulcastAlternatives {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeSimulcast {
     pub send: Vec<SdpAttributeSimulcastAlternatives>,
     pub receive: Vec<SdpAttributeSimulcastAlternatives>,
@@ -164,6 +172,7 @@ impl SdpAttributeSimulcast {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeRtcp {
     pub port: u16,
     pub unicast_addr: Option<IpAddr>,
@@ -183,6 +192,7 @@ impl SdpAttributeRtcp {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeRtcpFb {
     pub payload_type: u32,
     // TODO parse this and use an enum instead?
@@ -190,6 +200,7 @@ pub struct SdpAttributeRtcpFb {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpAttributeDirection {
     Recvonly,
     Sendonly,
@@ -197,6 +208,7 @@ pub enum SdpAttributeDirection {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeExtmap {
     pub id: u16,
     pub direction: Option<SdpAttributeDirection>,
@@ -205,12 +217,14 @@ pub struct SdpAttributeExtmap {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeFmtp {
     pub payload_type: u8,
     pub tokens: Vec<String>,
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeFingerprint {
     // TODO turn the supported hash algorithms into an enum?
     pub hash_algorithm: String,
@@ -218,12 +232,14 @@ pub struct SdpAttributeFingerprint {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeSctpmap {
     pub port: u16,
     pub channels: u32,
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpAttributeGroupSemantic {
     LipSynchronization,
     FlowIdentification,
@@ -235,24 +251,28 @@ pub enum SdpAttributeGroupSemantic {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeGroup {
     pub semantics: SdpAttributeGroupSemantic,
     pub tags: Vec<String>,
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeMsid {
     pub id: String,
     pub appdata: Option<String>,
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeMsidSemantic {
     pub semantic: String,
     pub msids: Vec<String>,
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeRtpmap {
     pub payload_type: u8,
     pub codec_name: String,
@@ -276,6 +296,7 @@ impl SdpAttributeRtpmap {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpAttributeSetup {
     Active,
     Actpass,
@@ -284,6 +305,7 @@ pub enum SdpAttributeSetup {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpAttributeSsrc {
     pub id: u32,
     pub attribute: Option<String>,
@@ -311,6 +333,7 @@ impl SdpAttributeSsrc {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpAttribute {
     BundleOnly,
     Candidate(SdpAttributeCandidate),

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,12 +124,12 @@ impl Serialize for SdpParserError {
         match self {
             &SdpParserError::Line {ref error, ref line, ..} => {
                 state.serialize_field("type", "Line")?;
-                state.serialize_field("internal", &format!("{}", error))?;
+                state.serialize_field("message", &format!("{}", error))?;
                 state.serialize_field("line", &line)?
             },
             &SdpParserError::Unsupported {ref error, ref line, ..} => {
                 state.serialize_field("type", "Unsupported")?;
-                state.serialize_field("internal", &format!("{}", error))?;
+                state.serialize_field("message", &format!("{}", error))?;
                 state.serialize_field("line", &line)?
             },
             &SdpParserError::Sequence {ref message, ..} => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::net::AddrParseError;
 use std::fmt;
 use std::error;
 use std::error::Error;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 use serde::ser::{Serializer, Serialize, SerializeStruct};
 
 
@@ -114,7 +114,7 @@ pub enum SdpParserError {
     Sequence { message: String, line_number: usize },
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 impl Serialize for SdpParserError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         let mut state = serializer.serialize_struct("error", match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 
-#[cfg(feature="serde")]
+#[cfg(feature="serialize")]
 #[macro_use]
 extern crate serde_derive;
-#[cfg(feature="serde")]
+#[cfg(feature="serialize")]
 extern crate serde;
 
 use std::net::IpAddr;
@@ -23,7 +23,7 @@ use unsupported_types::{parse_email, parse_information, parse_key, parse_phone, 
                         parse_uri, parse_zone};
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpBandwidth {
     As(u32),
     Ct(u32),
@@ -32,7 +32,7 @@ pub enum SdpBandwidth {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpConnection {
     pub addr: IpAddr,
     pub ttl: Option<u8>,
@@ -40,7 +40,7 @@ pub struct SdpConnection {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpOrigin {
     pub username: String,
     pub session_id: u64,
@@ -60,14 +60,14 @@ impl fmt::Display for SdpOrigin {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpTiming {
     pub start: u64,
     pub stop: u64,
 }
 
 
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpType {
     Attribute(SdpAttribute),
     Bandwidth(SdpBandwidth),
@@ -86,13 +86,13 @@ pub enum SdpType {
     Zone(String),
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpLine {
     pub line_number: usize,
     pub sdp_type: SdpType,
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpSession {
     pub version: u64,
     pub origin: SdpOrigin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 
+#[cfg(feature="serde")]
+#[macro_use]
+extern crate serde_derive;
+#[cfg(feature="serde")]
+extern crate serde;
+
 use std::net::IpAddr;
 use std::fmt;
 
@@ -17,6 +23,7 @@ use unsupported_types::{parse_email, parse_information, parse_key, parse_phone, 
                         parse_uri, parse_zone};
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpBandwidth {
     As(u32),
     Ct(u32),
@@ -25,6 +32,7 @@ pub enum SdpBandwidth {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpConnection {
     pub addr: IpAddr,
     pub ttl: Option<u8>,
@@ -32,6 +40,7 @@ pub struct SdpConnection {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpOrigin {
     pub username: String,
     pub session_id: u64,
@@ -51,11 +60,14 @@ impl fmt::Display for SdpOrigin {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpTiming {
     pub start: u64,
     pub stop: u64,
 }
 
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpType {
     Attribute(SdpAttribute),
     Bandwidth(SdpBandwidth),
@@ -74,11 +86,13 @@ pub enum SdpType {
     Zone(String),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpLine {
     pub line_number: usize,
     pub sdp_type: SdpType,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpSession {
     pub version: u64,
     pub origin: SdpOrigin,

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -4,6 +4,7 @@ use attribute_type::SdpAttribute;
 use error::{SdpParserError, SdpParserInternalError};
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpMediaLine {
     pub media: SdpMediaValue,
     pub port: u32,
@@ -13,6 +14,7 @@ pub struct SdpMediaLine {
 }
 
 #[derive(Clone,Debug,PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpMediaValue {
     Audio,
     Video,
@@ -31,6 +33,7 @@ impl fmt::Display for SdpMediaValue {
 }
 
 #[derive(Clone,Debug,PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpProtocolValue {
     RtpSavpf,
     UdpTlsRtpSavpf,
@@ -55,6 +58,7 @@ impl fmt::Display for SdpProtocolValue {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum SdpFormatList {
     Integers(Vec<u32>),
     Strings(Vec<String>),
@@ -69,6 +73,7 @@ impl fmt::Display for SdpFormatList {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct SdpMedia {
     media: SdpMediaLine,
     connection: Option<SdpConnection>,
@@ -167,6 +172,7 @@ impl SdpMedia {
 }
 
 #[cfg(test)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub fn create_dummy_media_section() -> SdpMedia {
     let media_line = SdpMediaLine {
         media: SdpMediaValue::Audio,

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -4,7 +4,7 @@ use attribute_type::SdpAttribute;
 use error::{SdpParserError, SdpParserInternalError};
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpMediaLine {
     pub media: SdpMediaValue,
     pub port: u32,
@@ -14,7 +14,7 @@ pub struct SdpMediaLine {
 }
 
 #[derive(Clone,Debug,PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpMediaValue {
     Audio,
     Video,
@@ -33,7 +33,7 @@ impl fmt::Display for SdpMediaValue {
 }
 
 #[derive(Clone,Debug,PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpProtocolValue {
     RtpSavpf,
     UdpTlsRtpSavpf,
@@ -58,7 +58,7 @@ impl fmt::Display for SdpProtocolValue {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum SdpFormatList {
     Integers(Vec<u32>),
     Strings(Vec<String>),
@@ -73,7 +73,7 @@ impl fmt::Display for SdpFormatList {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct SdpMedia {
     media: SdpMediaLine,
     connection: Option<SdpConnection>,
@@ -172,7 +172,7 @@ impl SdpMedia {
 }
 
 #[cfg(test)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub fn create_dummy_media_section() -> SdpMedia {
     let media_line = SdpMediaLine {
         media: SdpMediaValue::Audio,


### PR DESCRIPTION
This adds the `serialize` feature. When enabled, this feature adds serde serializers to the session and error object hierarchies.