### PR TITLE
Add dyn to error::Error impl function cause

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,7 @@ impl error::Error for SdpParserInternalError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             SdpParserInternalError::Integer(ref error) => Some(error),
             SdpParserInternalError::Float(ref error) => Some(error),
@@ -241,7 +241,7 @@ impl error::Error for SdpParserError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             SdpParserError::Line { ref error, .. }
             | SdpParserError::Unsupported { ref error, .. } => Some(error),


### PR DESCRIPTION
This fixes the warning trait objects without an explicit `dyn` are deprecated,
which causes builds with warnings-as-errors to fail. The error can be
triggered in standalone rsdparsa builds by setting
RUSTFLAGS="-D bare-trait-objects" when invoking cargo build.