### PR TITLE
Updating the minimum rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ rust:
   - beta
   - stable
   # minimum stable version
-  - 1.17.0
+  - 1.30.0
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A SDP parser written in Rust specifically aimed to handle WebRTC SDP offers and 
 
 ## Dependecies
 
-* Rust >= 1.17.0
+* Rust >= 1.30.0
 * log module
 * serde module
 * serde-derive module


### PR DESCRIPTION
Updates the minimum version of rust to 1.30. Closes #113