### PR TITLE
Fix inclusive ranges, and unnecessary muts, closing #131

### DIFF
--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -1817,7 +1817,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
                 // H264
                 "PROFILE-LEVEL-ID" => {
                     parameters.profile_level_id = match u32::from_str_radix(parameter_val, 16)? {
-                        x @ 0...0x00ff_ffff => x,
+                        x @ 0..=0x00ff_ffff => x,
                         _ => return Err(SdpParserInternalError::Generic(
                             "The fmtp parameter 'profile-level-id' must be in range [0,0xffffff]"
                                 .to_string(),
@@ -1826,7 +1826,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
                 }
                 "PACKETIZATION-MODE" => {
                     parameters.packetization_mode = match parameter_val.parse::<u32>()? {
-                        x @ 0...2 => x,
+                        x @ 0..=2 => x,
                         _ => {
                             return Err(SdpParserInternalError::Generic(
                                 "The fmtp parameter 'packetization-mode' must be 0,1 or 2"
@@ -1864,7 +1864,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
 
         for encoding in encodings {
             match encoding.parse::<u8>()? {
-                x @ 0...128 => parameters.encodings.push(x),
+                x @ 0..=128 => parameters.encodings.push(x),
                 _ => {
                     return Err(SdpParserInternalError::Generic(
                         "Red codec must be in range [0,128]".to_string(),
@@ -1881,7 +1881,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
         let validate_digits = |digit_option: Option<u8>| -> Option<u8> {
             match digit_option {
                 Some(x) => match x {
-                    0...100 => Some(x),
+                    0..=100 => Some(x),
                     _ => None,
                 },
                 None => None,
@@ -3486,7 +3486,7 @@ mod tests {
         if let SdpType::Attribute(SdpAttribute::RemoteCandidate(remote)) =
             parse_attribute("remote-candidates:0 10.0.0.1 5555")?
         {
-            let mut masked = remote.masked_clone(&mut anon);
+            let masked = remote.masked_clone(&mut anon);
             assert_eq!(masked.address, std::net::Ipv4Addr::from(1));
             assert_eq!(masked.port, 1);
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1443,7 +1443,7 @@ a=ice-lite\r\n",
                 attributes.push(attribute.clone());
             }
         }
-        for mut attribute in attributes {
+        for attribute in attributes {
             match attribute {
                 SdpAttribute::Candidate(c) => {
                     assert_eq!(c.address, std::net::Ipv4Addr::from(3));

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -371,7 +371,7 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
                     8  |  // PCMA
                     9  |  // G722
                     13 |  // Comfort Noise
-                    96 ... 127 => (),  // dynamic range
+                    96 ..= 127 => (),  // dynamic range
                     _ => return Err(SdpParserInternalError::Generic(
                           "format number in media line is out of range".to_string()))
                 };


### PR DESCRIPTION
This removes the current compilation warnings, which are use of the deprecate `...` inclusive range operator, and some unnecessary muts.